### PR TITLE
docs: mention new file and fix description of php-version.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,9 @@ Static JSON information about Shopware
   - Contains all Security Advisories
   - Contains an mapping of Shopware Version to Advistory
 - [php-version.json](https://github.com/FriendsOfShopware/shopware-static-data/blob/main/data/php-version.json)
+  - Contains each Shopware Version with their minimum PHP version requirement
+
+- [all-supported-php-versions-by-shopware-version.json.json](https://github.com/FriendsOfShopware/shopware-static-data/blob/main/data/all-supported-php-versions-by-shopware-version.json.json)
   - Contains each Shopware Version with a list of corresponding supported PHP versions
+
+


### PR DESCRIPTION
This was an oversight, after we decided to create a new file for all PHP versions to not break implementations of php-versios.json